### PR TITLE
Add test for spawning a daemon process

### DIFF
--- a/readAndExecute.go
+++ b/readAndExecute.go
@@ -219,7 +219,6 @@ func execCmd(command *command, received *receivedStruct, result *answer, config 
 
 	// https://github.com/golang/go/issues/18874
 	// timeout does not work for child processes and/or if file handles are still open
-	// TODO: This could be the source of the zombies (go keyword)
 	go func(proc *os.Process) {
 		defer logPanicExit()
 		<-ctx.Done() // wait till command runs into timeout or is finished (canceled)

--- a/readAndExecute.go
+++ b/readAndExecute.go
@@ -219,6 +219,7 @@ func execCmd(command *command, received *receivedStruct, result *answer, config 
 
 	// https://github.com/golang/go/issues/18874
 	// timeout does not work for child processes and/or if file handles are still open
+	// TODO: This could be the source of the zombies (go keyword)
 	go func(proc *os.Process) {
 		defer logPanicExit()
 		<-ctx.Done() // wait till command runs into timeout or is finished (canceled)

--- a/readAndExecute_test.go
+++ b/readAndExecute_test.go
@@ -198,36 +198,8 @@ func TestExecuteCommandWithTimeoutII(t *testing.T) {
 	config.timeoutReturn = 3
 	result = &answer{}
 
-	//executeCommandLine(result, &receivedStruct{commandLine: `sleep 30`, timeout: 50}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `python3 /tmp/python-test-d.py`, timeout: 5}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `(sleep 30 &)`, timeout: 5}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 25}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import subprocess; import socket; p = subprocess.Popen('sleep 600', stdout=subprocess.PIPE, shell=True); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 4}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import subprocess; import socket; p = subprocess.Popen(['/bin/python2.7', '-c' ,'\"import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind((\'localhost\', 50001)); s.listen(1); fd, addr = s.accept();\"'], stdout=subprocess.PIPE, shell=False); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 3}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `nohup python3 -c "import subprocess; import socket; p = subprocess.Popen(['/bin/python2.7', '-c' ,'\"import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind((\'localhost\', 50001)); s.listen(1); fd, addr = s.accept();\"'], stdout=subprocess.PIPE, shell=False); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();" &`, timeout: 3}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `nohup python3 -c "import subprocess; import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 3}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `bash -c "(nohup python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept(); &) ; disown -a"`, timeout: 3}, &config)
+	// Spawning a daemon process
 	executeCommandLine(result, &receivedStruct{commandLine: `python3 test/python-daemon.py`, timeout: 3}, &config)
-
-	// func1 := func() {
-	// }
-	// func2 := func() {
-	// 	executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();""`, timeout: 10}, &config)
-	// }
-	// func3 := func() {
-	// 	executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 10}, &config)
-	// }
-	// func4 := func() {
-	// 	executeCommandLine(result, &receivedStruct{commandLine: `trap 'echo Booh!' SIGINT SIGTERM; sleep 2"`, timeout: 10}, &config)
-	// }
-	// func5 := func() {
-	// 	executeCommandLine(result, &receivedStruct{commandLine: `/bin/sh -c \"trap 'echo Booh!' SIGINT SIGTERM; sleep 2\"`, timeout: 10}, &config)
-	// }
-	// func6 := func() {
-	// 	executeCommandLine(result, &receivedStruct{commandLine: `python2.7 -c "echo hi"`, timeout: 10}, &config)
-	// }
-
-	//Parallelize(func1,func2,func3,func4,func5,func6)
 
 	if !strings.HasPrefix(result.output, "(Check Timed Out On Worker:") || result.returnCode != 3 {
 		t.Errorf("got %s, with code: %d but expected: %s and code: %d", result.output, result.returnCode, "timeout", 3)

--- a/readAndExecute_test.go
+++ b/readAndExecute_test.go
@@ -198,11 +198,16 @@ func TestExecuteCommandWithTimeoutII(t *testing.T) {
 	config.timeoutReturn = 3
 	result = &answer{}
 
-	//executeCommandLine(result, &receivedStruct{commandLine: `sleep 30`, timeout: 2}, &config)
-	//executeCommandLine(result, &receivedStruct{commandLine: `python /tmp/test.py"`, timeout: 5}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `sleep 30`, timeout: 50}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `python3 /tmp/python-test-d.py`, timeout: 5}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `(sleep 30 &)`, timeout: 5}, &config)
 	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 25}, &config)
 	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import subprocess; import socket; p = subprocess.Popen('sleep 600', stdout=subprocess.PIPE, shell=True); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 4}, &config)
-	executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import subprocess; import socket; p = subprocess.Popen(['/bin/python2.7', '-c' ,'\"import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind((\'localhost\', 50001)); s.listen(1); fd, addr = s.accept();\"'], stdout=subprocess.PIPE, shell=False); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 7}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `python3 -c "import subprocess; import socket; p = subprocess.Popen(['/bin/python2.7', '-c' ,'\"import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind((\'localhost\', 50001)); s.listen(1); fd, addr = s.accept();\"'], stdout=subprocess.PIPE, shell=False); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 3}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `nohup python3 -c "import subprocess; import socket; p = subprocess.Popen(['/bin/python2.7', '-c' ,'\"import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind((\'localhost\', 50001)); s.listen(1); fd, addr = s.accept();\"'], stdout=subprocess.PIPE, shell=False); p.kill(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();" &`, timeout: 3}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `nohup python3 -c "import subprocess; import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept();"`, timeout: 3}, &config)
+	//executeCommandLine(result, &receivedStruct{commandLine: `bash -c "(nohup python3 -c "import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('localhost', 50000)); s.listen(1); fd, addr = s.accept(); &) ; disown -a"`, timeout: 3}, &config)
+	executeCommandLine(result, &receivedStruct{commandLine: `python3 test/python-daemon.py`, timeout: 3}, &config)
 
 	// func1 := func() {
 	// }
@@ -224,8 +229,6 @@ func TestExecuteCommandWithTimeoutII(t *testing.T) {
 
 	//Parallelize(func1,func2,func3,func4,func5,func6)
 
-	for {
-	}
 	if !strings.HasPrefix(result.output, "(Check Timed Out On Worker:") || result.returnCode != 3 {
 		t.Errorf("got %s, with code: %d but expected: %s and code: %d", result.output, result.returnCode, "timeout", 3)
 	}

--- a/readAndExecute_test.go
+++ b/readAndExecute_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -169,20 +168,6 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 
 	if !strings.Contains(result.output, `)\nkilling\nme...\n[stderr\nstderr]`) || result.returnCode != 2 {
 		t.Errorf("got result %s, but expected containing %s", result.output, `)\nkilling\nme...\n[stderr\nstderr]`)
-	}
-}
-
-// Parallelize parallelizes the function calls
-func Parallelize(functions ...func()) {
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(functions))
-
-	defer waitGroup.Wait()
-
-	for _, function := range functions {
-		go func(f func()) {
-			f()
-		}(function)
 	}
 }
 

--- a/test/python-daemon.py
+++ b/test/python-daemon.py
@@ -1,0 +1,35 @@
+import sys, os, time
+
+def main():
+    time.sleep(200)
+
+if __name__ == "__main__":
+    # Do the Unix double-fork magic; see Stevens's book "Advanced
+    # Programming in the UNIX Environment" (Addison-Wesley) for details
+    try:
+        pid = os.fork()
+        if pid > 0:
+            # Exit first parent
+            sys.exit(0)
+    except OSError as e:
+        print("fork #1 failed: %d (%s)" % (
+            e.errno, e.strerror), file=sys.stderr)
+        sys.exit(1)
+
+    # Decouple from parent environment
+    os.setsid()
+
+    # Do second fork
+    try:
+        pid = os.fork()
+        if pid > 0:
+            # Exit from second parent; print eventual PID before exiting
+            print("Daemon PID %d" % pid)
+            sys.exit(0)
+    except OSError as e:
+        print("fork #2 failed: %d (%s)" % (
+            e.errno, e.strerror), file=sys.stderr)
+        sys.exit(1)
+
+    # Start the daemon main loop
+    main()


### PR DESCRIPTION
This test spawns a daemon thread which is not handled by the timeout. It would be nice if the mod-gearman-worker could handle that.

If this process then returns, its parent (the mod-gearman-worker) does NOT execute the `.wait` syscall, which in return leaves a zombie process.
