### PR TITLE
Add an option to display worker identifier in result output

### DIFF
--- a/configuration_parser.go
+++ b/configuration_parser.go
@@ -74,6 +74,8 @@ type configurationStruct struct {
 	flagProfile    string
 	flagCPUProfile string
 	flagMemProfile string
+	// append worker hostname to result output
+	workerNameInResult bool
 }
 
 // setDefaultValues sets reasonable defaults
@@ -102,6 +104,7 @@ func (config *configurationStruct) setDefaultValues() {
 	config.internalNegate = true
 	config.internalCheckDummy = true
 	config.internalCheckNscWeb = true
+	config.workerNameInResult = false
 	filename, err := os.Executable()
 	if err == nil {
 		config.p1File = path.Join(path.Dir(filename), "mod_gearman_worker_epn.pl")
@@ -169,6 +172,7 @@ func (config *configurationStruct) dump() {
 	logger.Debugf("internal_negate               %v\n", config.internalNegate)
 	logger.Debugf("internal_check_dummy          %v\n", config.internalCheckDummy)
 	logger.Debugf("internal_check_nsc_web        %v\n", config.internalCheckNscWeb)
+	logger.Debugf("worker_name_in_result         %v\n", config.workerNameInResult)
 	if config.binary == "send_gearman" {
 		logger.Debugf("returncode                    %d\n", config.returnCode)
 		logger.Debugf("message                       %s\n", config.message)
@@ -330,6 +334,8 @@ func (config *configurationStruct) parseConfigItem(raw string) error {
 		config.internalCheckDummy = getBool(value)
 	case "internal_check_nsc_web":
 		config.internalCheckNscWeb = getBool(value)
+	case "worker_name_in_result":
+		config.workerNameInResult = getBool(value)
 	case "fork_on_exec":
 		// skip legacy option
 	case "workaround_rc_25":

--- a/readAndExecute.go
+++ b/readAndExecute.go
@@ -287,6 +287,9 @@ func execEPN(result *answer, cmd *command, received *receivedStruct) {
 
 func fixReturnCodes(result *answer, config *configurationStruct, state *os.ProcessState) {
 	if result.returnCode >= 0 && result.returnCode <= 3 {
+		if config.workerNameInResult {
+		result.output = fmt.Sprintf("%s (worker: %s)", result.output, config.identifier)
+		}
 		return
 	}
 	if result.returnCode == exitCodeNotExecutable {

--- a/readAndExecute.go
+++ b/readAndExecute.go
@@ -288,7 +288,7 @@ func execEPN(result *answer, cmd *command, received *receivedStruct) {
 func fixReturnCodes(result *answer, config *configurationStruct, state *os.ProcessState) {
 	if result.returnCode >= 0 && result.returnCode <= 3 {
 		if config.workerNameInResult {
-		result.output = fmt.Sprintf("%s (worker: %s)", result.output, config.identifier)
+			result.output = fmt.Sprintf("%s (worker: %s)", result.output, config.identifier)
 		}
 		return
 	}

--- a/worker.cfg
+++ b/worker.cfg
@@ -234,6 +234,10 @@ use_perl_cache=on
 #internal_check_dummy = 1
 
 
+# Show worker identifier in result output
+#worker_name_in_result=no
+
+
 # Prometheus
 # export prometheus metrics
 #prometheus_server=127.0.0.1:9050


### PR DESCRIPTION
There is a need to always see the worker identifier where the checks are being executed.